### PR TITLE
Specify '&' as arg separator in http_build_query() call

### DIFF
--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -391,7 +391,7 @@ class Tokens extends Base
             $url,
             array(
                 'method' => 'POST',
-                'body' => http_build_query($query),
+                'body' => http_build_query($query, '', '&'),
             )
         );
     }


### PR DESCRIPTION
PHP's http_build_query() function seems to use the HTML entity '&amp;' as the default argument separator, which can result in an exception when requesting an OAuth 2.0 token from Persona:

"Did not retrieve successful response code from persona: HTTP/1.1 400 Bad Request ... error_description: client credentials were not found in the headers or body".

Specifying the unencoded version '&' instead works fine.
